### PR TITLE
PCP-253 Make expected eventmachine thread usage part of the contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ To connect to a broker and send and receive messages:
 ```ruby
 require 'pcp/client'
 
-# Start an eventmachine main loop
+# Start the eventmachine reactor in its own thread
 Thread.new { EM.run }
+Thread.pass until EM.reactor_running?
 
 client = PCP::Client.new({:server => 'wss://localhost:8142/pcp',
                           :ssl_key => 'test-resources/ssl/private_keys/client01.example.com.pem',
@@ -44,8 +45,9 @@ A matching agent that would respond to this may look like this:
 ```ruby
 require 'pcp/client'
 
-# Start an eventmachine main loop
+# Start the eventmachine reactor in its own thread
 Thread.new { EM.run }
+Thread.pass until EM.reactor_running?
 
 client = PCP::Client.new({:server => 'wss://localhost:8142/pcp',
                           :ssl_key => 'test-resources/ssl/private_keys/client02.example.com.pem',
@@ -71,6 +73,7 @@ loop do end
 
 There's a more extended example of this which makes more use of
 PCP/PXP features in bin/pcp-ping.
+
 
 Testing
 =======

--- a/bin/pcp-ping
+++ b/bin/pcp-ping
@@ -4,6 +4,7 @@ require 'pcp/client'
 start_time = Time.now.to_f
 
 Thread.new { EM.run }
+Thread.pass until EM.reactor_running?
 
 client = PCP::Client.new({:ssl_key => 'test-resources/ssl/private_keys/client04.example.com.pem',
                           :ssl_cert => 'test-resources/ssl/certs/client04.example.com.pem'})

--- a/lib/pcp/client.rb
+++ b/lib/pcp/client.rb
@@ -42,6 +42,17 @@ module PCP
     # @param seconds [Numeric]
     # @return [true,false,nil]
     def connect(seconds = 0)
+      unless EM.reactor_running?
+        raise "An Eventmachine reactor needs to be running"
+      end
+
+      if EM.reactor_thread?
+        # Because we use a condition variable to signal this thread
+        # from the reactor thread to provide an imperative interface,
+        # they cannot be the same thread
+        raise "Cannot be run on the same thread as the reactor"
+      end
+
       mutex = Mutex.new
       associated_cv = ConditionVariable.new
 


### PR DESCRIPTION
Here we make the contract between eventmachine reactor thread and PCP::Client#connect more explicit by raising if the #connect method detects it will be unable to provide the intended behaviour.

We also make the example uses wait on EM.reactor_running? to avoid a race between the reactor thread starting and #connect trying to use it.