### PR TITLE
PCP-300 expose more state

### DIFF
--- a/lib/pcp/client.rb
+++ b/lib/pcp/client.rb
@@ -53,6 +53,11 @@ module PCP
         raise "Cannot be run on the same thread as the reactor"
       end
 
+      if @connection
+        # We close over so much, we really just need to say no for now
+        raise "Can only connect once per client"
+      end
+
       mutex = Mutex.new
       associated_cv = ConditionVariable.new
 

--- a/lib/pcp/client.rb
+++ b/lib/pcp/client.rb
@@ -27,7 +27,7 @@ module PCP
       @server = params[:server] || 'wss://localhost:8142/pcp'
       @ssl_key = params[:ssl_key]
       @ssl_cert = params[:ssl_cert]
-      @logger = Logger.new(STDOUT)
+      @logger = params[:logger] || Logger.new(STDOUT)
       @logger.level = params[:loglevel] || Logger::WARN
       @connection = nil
       type = params[:type] || "ruby-pcp-client-#{$$}"

--- a/lib/pcp/simple_logger.rb
+++ b/lib/pcp/simple_logger.rb
@@ -1,0 +1,25 @@
+require 'logger'
+
+# This logger just adds events to the @events property, so when you
+# .inspect it you can see what was logged.
+module PCP
+  class SimpleLogger < ::Logger
+    def initialize(*args)
+      @events = []
+    end
+
+    def add(severity, message = nil, progname = nil)
+      if message.nil?
+        if block_given?
+          message = yield
+        else
+          message = progname
+        end
+      end
+
+      @events << {:when => Time.now.to_f,
+                  :severity => severity,
+                  :message => message}
+    end
+  end
+end


### PR DESCRIPTION
Here we add the ability to supply a logger, and a logger that keeps messages in memory.  These combined should allow for additional debugging of client state post-connection attempt.