### PR TITLE
PCP-361 Add explicit close to the api

### DIFF
--- a/lib/pcp/client.rb
+++ b/lib/pcp/client.rb
@@ -141,6 +141,14 @@ module PCP
       @connection.send(message.encode)
     end
 
+    # Disconnect the client
+    # @api public
+    # @return unused
+    def close
+      @logger.debug { [:close] }
+      @connection.close
+    end
+
     private
 
     # Get the common name from an X509 certficate in file


### PR DESCRIPTION
Earlier example uses of this code didn't have a lifecycle that really needed a
close method, so as an oversight this was missing leading to a more error-prone
attempts to shut things down by restarting Eventmachine repeatedly.