### PR TITLE
PCP-179 use pure eventmachine again

### DIFF
--- a/lib/pcp/client.rb
+++ b/lib/pcp/client.rb
@@ -1,4 +1,4 @@
-require 'eventmachine-le'
+require 'eventmachine'
 require 'faye/websocket'
 require 'pcp/message'
 require 'logger'
@@ -64,7 +64,7 @@ module PCP
       @logger.debug { [:connect, @server] }
       @connection = Faye::WebSocket::Client.new(@server, nil, {:tls => {:private_key_file => @ssl_key,
                                                                         :cert_chain_file => @ssl_cert,
-                                                                        :ssl_version => :TLSv1}})
+                                                                        :ssl_version => ["TLSv1_2"]}})
 
       @connection.on :open do |event|
         begin

--- a/pcp-client.gemspec
+++ b/pcp-client.gemspec
@@ -8,8 +8,7 @@ Gem::Specification.new do |s|
   s.authors     = ["Puppet Labs"]
   s.email       = "puppet@puppetlabs.com"
   s.files       = Dir["lib/**/*.rb"]
-  # TODO(PCP-179): switch back to eventmachine 1.2 when available
-  s.add_runtime_dependency 'eventmachine-le', '~> 1.1'
+  s.add_runtime_dependency 'eventmachine', '~> 1.2'
   s.add_runtime_dependency 'faye-websocket', '~> 0.10'
   s.add_runtime_dependency 'rschema', '~> 1.3'
 end


### PR DESCRIPTION
eventmachine's 1.2 release allows us to use eventmachine on it's own for our
SSL needs, rather than needing to use the options added by eventmachine-le.
This has the side benefit in that it improves our ruby compatibility matrix, as
eventmachine-le does not support ruby 2.2.