### PR TITLE
(maint) accept TLS version 1.0 and 1.1

### DIFF
--- a/lib/pcp/client.rb
+++ b/lib/pcp/client.rb
@@ -64,7 +64,7 @@ module PCP
       @logger.debug { [:connect, @server] }
       @connection = Faye::WebSocket::Client.new(@server, nil, {:tls => {:private_key_file => @ssl_key,
                                                                         :cert_chain_file => @ssl_cert,
-                                                                        :ssl_version => ["TLSv1_2"]}})
+                                                                        :ssl_version => ["TLSv1", "TLSv1_1", "TLSv1_2"]}})
 
       @connection.on :open do |event|
         begin


### PR DESCRIPTION
In testing James Stocks found that it some combinations of openssl
library and ruby interpreter do not yet offer TLSv1.2, so the earlier
change was too agressive and broke compatibilty in some cases.

Here we specify that TLS versions 1.0, 1.1, and 1.2 are all acceptable.