### PR TITLE
PCP-366 perform ssl verification

### DIFF
--- a/bin/pcp-ping
+++ b/bin/pcp-ping
@@ -2,15 +2,17 @@
 require 'pcp/client'
 require 'optparse'
 
-ssl_key = 'test-resources/ssl/private_keys/client04.example.com.pem'
-ssl_cert = 'test-resources/ssl/certs/client04.example.com.pem'
+ssl_key = '../pcp-broker/test-resources/ssl/private_keys/client01.example.com.pem'
+ssl_cert = '../pcp-broker/test-resources/ssl/certs/client01.example.com.pem'
+ssl_ca_cert = '../pcp-broker/test-resources/ssl/ca/ca_crt.pem'
 debug = false
-server = 'wss://127.0.0.1:8142/pcp'
+server = 'wss://localhost:8142/pcp'
 
 OptionParser.new do |opts|
   opts.on("-d",  "--debug", "Run noisily") { |v| debug = v }
   opts.on("--ssl_key FILE", "Use this ssl key") { |v| ssl_key = v }
   opts.on("--ssl_cert FILE", "Use this ssl cert") { |v| ssl_cert = v }
+  opts.on("--ssl_ca_cert FILE", "Use this ssl ca cert") { |v| ssl_ca_cert = v }
   opts.on("--server URL", "Server to connect to") { |v| server = v }
 end.parse!
 
@@ -21,6 +23,7 @@ Thread.pass until EM.reactor_running?
 
 client = PCP::Client.new({:ssl_key => ssl_key,
                           :ssl_cert => ssl_cert,
+                          :ssl_ca_cert => ssl_ca_cert,
                           :loglevel => debug ? Logger::DEBUG : Logger::WARN,
                           :server => server,
                          })


### PR DESCRIPTION
Here we add verification that the peer certificate matches the name that we
connected with, and was issued by a known CA (identified by the new ssl_ca_cert
parameter)