### PR TITLE
(PCP-480) Allow setting max message size

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ loop do end
 There's a more extended example of this which makes more use of
 PCP/PXP features in bin/pcp-ping.
 
+## Options
+
+`PCP::Client` takes several additional options:
+
+* `logger` - specify a logging target extending the Logger class
+* `loglevel` - specify one of the levels supported by the Logger class
+* `on_message` - specify an `on_message` handler during construction
+* `max_message_size` - change the limit on maximum incoming message size (defaults to 64MiB)
 
 ## Testing
 

--- a/lib/pcp/client.rb
+++ b/lib/pcp/client.rb
@@ -80,6 +80,7 @@ module PCP
       type = params[:type] || "ruby-pcp-client-#{$$}"
       @identity = make_identity(@ssl_cert, type)
       @on_message = params[:on_message]
+      @max_message_size = params[:max_message_size] || 64*1024*1024
       @associated = false
     end
 
@@ -114,7 +115,9 @@ module PCP
           :xxx_hostname => URI.parse(@server).host,
         }
 
-        @connection = Faye::WebSocket::Client.new(@server, nil, {:tls => start_tls_options, :ping => 30})
+        @connection = Faye::WebSocket::Client.new(@server, nil, {:tls => start_tls_options,
+                                                                 :ping => 30,
+                                                                 :max_length => @max_message_size})
 
         @connection.on :open do |event|
           begin

--- a/pcp-client.gemspec
+++ b/pcp-client.gemspec
@@ -5,9 +5,10 @@ Gem::Specification.new do |s|
   s.summary     = "Client library for PCP"
   s.description = "See https://github.com/puppetlabs/pcp-specifications"
   s.homepage    = 'https://github.com/puppetlabs/ruby-pcp-client'
-  s.authors     = ["Puppet Labs"]
-  s.email       = "puppet@puppetlabs.com"
-  s.files       = Dir["lib/**/*.rb"]
+  s.authors     = ['Puppet Labs']
+  s.email       = 'puppet@puppetlabs.com'
+  s.files       = Dir['lib/**/*.rb']
+  s.executables = ['pcp-ping']
   s.add_runtime_dependency 'eventmachine', '~> 1.2'
   s.add_runtime_dependency 'faye-websocket', '~> 0.10'
   s.add_runtime_dependency 'rschema', '~> 1.3'


### PR DESCRIPTION
Without this change, the maximum size of a message the client can
receive is 64MiB. A PCP message can be up to 2GiB. Make the message size
configurable.
