### PR TITLE
Pass the :ping option so that connections stay alive

### DIFF
--- a/lib/pcp/client.rb
+++ b/lib/pcp/client.rb
@@ -114,7 +114,7 @@ module PCP
           :xxx_hostname => URI.parse(@server).host,
         }
 
-        @connection = Faye::WebSocket::Client.new(@server, nil, {:tls => start_tls_options})
+        @connection = Faye::WebSocket::Client.new(@server, nil, {:tls => start_tls_options, :ping => 30})
 
         @connection.on :open do |event|
           begin


### PR DESCRIPTION
Prior to this, the websocket connection would time out after a few minutes. This lets you have long-running connections, which are real handy when writing an agent that should maintain a connection ;-)

Thanks for the tip, @richardc