### PR TITLE
(PCP-674) Mark repo unmaintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# pcp-client
+# pcp-client (unmaintained)
 
-This library provides a client library for the [Puppet Communications Protocol](https://github.com/puppetlabs/pcp-specifications) wire protocol.
+This library provides a client library for the [Puppet Communications Protocol](https://github.com/puppetlabs/pcp-specifications) wire protocol version 1.
+
+The library is not expected to receive any future updates beyond those necessary for its role in testing other components. Notably it does not support PCP v2.
 
 ## Basic Usage
 


### PR DESCRIPTION
Update the ruby-pcp-client README to note that it only supports PCP v1,
and will not be updated in the future beyond necessary bug fixes for
testing other components.