### PR TITLE
Require OpenSSL to fix Ruby 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,6 @@ notifications:
   email: false
 rvm:
   - 2.1.7
+  - 2.3.4
+  - 2.4.4
+  - 2.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.5.0
+
+- Add validate function to Message class, default message expiration to 3s (#21)
+- [PCP-480](https://tickets.puppetlabs.com/browse/PCP-480) Option to set
+  max message size allowed for received messages.
+- Enable websocket pings at 30s intervals (#24)
+- Fix for Ruby 2.5 (#28)
+
 ## 0.4.0
 
 - [PCP-366](https://tickets.puppetlabs.com/browse/PCP-366) New mandatory `:ssl_ca_cert`

--- a/lib/pcp/client.rb
+++ b/lib/pcp/client.rb
@@ -2,6 +2,7 @@ require 'eventmachine'
 require 'faye/websocket'
 require 'pcp/message'
 require 'logger'
+require 'openssl'
 
 # So EventMachine when you specify :verify_peer => true in the TLS
 # options decides what that means is it should just fire off a

--- a/pcp-client.gemspec
+++ b/pcp-client.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'pcp-client'
-  s.version     = '0.4.0'
+  s.version     = '0.5.0'
   s.licenses    = ['ASL 2.0']
   s.summary     = "Client library for PCP"
   s.description = "See https://github.com/puppetlabs/pcp-specifications"


### PR DESCRIPTION
Seems to be needed with Ruby 2.5.