### PR TITLE
(packaging) Update version to match CI automation

### DIFF
--- a/lib/pcp-client/version.rb
+++ b/lib/pcp-client/version.rb
@@ -1,0 +1,4 @@
+class PCPClient
+  VERSION = '0.4.0'.freeze
+end
+

--- a/pcp-client.gemspec
+++ b/pcp-client.gemspec
@@ -1,6 +1,10 @@
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+require 'pcp-client/version'
 Gem::Specification.new do |s|
   s.name        = 'pcp-client'
-  s.version     = '0.5.0'
+  s.version     = PCPClient::VERSION
   s.licenses    = ['ASL 2.0']
   s.summary     = "Client library for PCP"
   s.description = "See https://github.com/puppetlabs/pcp-specifications"


### PR DESCRIPTION
Jenkins CI scripts for bump and tag assume a `lib/pcp-client/version.rb`
file that describes the version. Add it and use that to derive the gem
version.