### PR TITLE
(PE-29831) Pin faye-websocket dependency

### DIFF
--- a/pcp-client.gemspec
+++ b/pcp-client.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |s|
   s.executables = ["pcp-ping"]
   s.files       = Dir["lib/**/*.rb"]
   s.add_runtime_dependency 'eventmachine', '~> 1.2'
-  s.add_runtime_dependency 'faye-websocket', '~> 0.10'
+  s.add_runtime_dependency 'faye-websocket', '0.10.9'
   s.add_runtime_dependency 'rschema', '~> 1.3'
 end


### PR DESCRIPTION
The 0.11.0 release of faye-websocket introduced new settings to configure tls https://github.com/faye/faye-websocket-ruby/commit/8b76cd904ae47a8eb641f45f8bf572a1ad94bb6e . We currently were monkey patching some behaviour around this that no longer works https://github.com/puppetlabs/ruby-pcp-client/blob/master/lib/pcp/client.rb . Given this gem is only used in CI and is no longer in active development, pin back to the library that works.