### PR TITLE
(maint) Update to faye-websocket >= 0.11 < 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ script:
 notifications:
   email: false
 rvm:
-  - 2.1.7
   - 2.3.4
   - 2.4.4
   - 2.5.1

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source 'https://rubygems.org'
 gemspec
 
 group(:development, :test) do
-  gem "rspec", '~> 3.3.0'
+  gem "rspec", '~> 3.3'
   gem 'devtools', '~> 0.1.0'
 end

--- a/lib/pcp/client.rb
+++ b/lib/pcp/client.rb
@@ -4,52 +4,6 @@ require 'pcp/message'
 require 'logger'
 require 'openssl'
 
-# So EventMachine when you specify :verify_peer => true in the TLS
-# options decides what that means is it should just fire off a
-# #ssl_verify_peer(cert) on the Connection object; which is expected
-# to be user-supplied.  In this case the user is
-# Faye::Websocket::Client::Connection, so we monkey-patch it to have a
-# #ssl_verify_peer method.
-
-module Faye
-  class WebSocket
-    class Client
-      module Connection
-        def ssl_verify_peer(cert)
-          # The :@socket_tls instance variable of
-          # Faye::Websocket::Client is passed to tls_start, so we can
-          # get parameters from there.
-          start_tls_options = parent.instance_variable_get(:@socket_tls)
-          logger = start_tls_options[:xxx_logger]
-          logger.debug { [:ssl_verify_peer] }
-
-          peer_cert = OpenSSL::X509::Certificate.new cert
-
-          hostname = start_tls_options[:xxx_hostname]
-          if !OpenSSL::SSL.verify_certificate_identity(peer_cert, hostname)
-            logger.error { [:ssl_verify_peer, :fail,
-                           "Certificate presented does not match '#{hostname}'"] }
-            return false
-          end
-
-          ssl_ca_cert = start_tls_options[:xxx_ssl_ca_cert]
-          cert_store = OpenSSL::X509::Store.new
-          cert_store.add_file ssl_ca_cert
-
-          if !cert_store.verify(peer_cert)
-            logger.error { [:ssl_verify_peer, :ca_verify_failed,
-                            "Peer certificate not verified by ca"] }
-            return false
-          end
-
-          logger.debug { [:ssl_verify_peer, :success] }
-          return true
-        end
-      end
-    end
-  end
-end
-
 module PCP
   # Manages a client connection to a pcp broker
   class Client
@@ -107,13 +61,9 @@ module PCP
           :ssl_version => ["TLSv1", "TLSv1_1", "TLSv1_2"],
           :private_key_file => @ssl_key,
           :cert_chain_file => @ssl_cert,
+          :root_cert_file => @ssl_ca_cert,
           :verify_peer => true,
           :fail_if_no_peer_cert => true,
-          # side-channeled properties we want around during ssl
-          # verification are prefixed with xxx_.
-          :xxx_logger => @logger,
-          :xxx_ssl_ca_cert => @ssl_ca_cert,
-          :xxx_hostname => URI.parse(@server).host,
         }
 
         @connection = Faye::WebSocket::Client.new(@server, nil, {:tls => start_tls_options,

--- a/pcp-client.gemspec
+++ b/pcp-client.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |s|
   s.executables = ["pcp-ping"]
   s.files       = Dir["lib/**/*.rb"]
   s.add_runtime_dependency 'eventmachine', '~> 1.2'
-  s.add_runtime_dependency 'faye-websocket', '0.10.9'
+  s.add_runtime_dependency 'faye-websocket', '~> 0.11.0'
   s.add_runtime_dependency 'rschema', '~> 1.3'
 end


### PR DESCRIPTION
Faye-websocket now handles ssl verification by default provided the
`root_cert_file` option is passed in[1]. This removes the monkey patching that
was necessary previously.

The rspec dependency had to be bumped to bundle install on ruby 2.5.8.

[1] https://github.com/faye/faye-websocket-ruby/blob/0.11.0/lib/faye/websocket/ssl_verifier.rb#L34